### PR TITLE
Add blog post: Proxmox 9 Boot Repair Session

### DIFF
--- a/posts/2026-03-20-proxmox-9-repair.html
+++ b/posts/2026-03-20-proxmox-9-repair.html
@@ -98,6 +98,7 @@
 </header>
 <nav id="TOC" role="doc-toc">
 <ul>
+<li><a href="#intro" id="toc-intro">Intro</a></li>
 <li><a href="#background" id="toc-background">Background</a>
 <ul>
 <li><a href="#what-happened" id="toc-what-happened">What
@@ -135,6 +136,13 @@ id="toc-step-7-cleanup-unmount">Step 7: Cleanup &amp; Unmount</a></li>
 <li><a href="#post-repair" id="toc-post-repair">Post-Repair</a></li>
 </ul>
 </nav>
+<h2 id="intro">Intro</h2>
+<p>I managed to botch my Proxmox installation in a rather classic way: I
+tried to upgrade from Debian 12 to 13 while watching <em>The Pitt</em>
+on HBO Max, only half paying attention. Predictably, I missed some
+critical pre-upgrade warnings, and my system wouldn’t boot. This post
+documents the successful repair procedure for anyone else who might find
+themselves in a similar situation (distracted or otherwise).</p>
 <h2 id="background">Background</h2>
 <h3 id="what-happened">What Happened</h3>
 <ul>

--- a/posts/2026-03-20-proxmox-9-repair.html
+++ b/posts/2026-03-20-proxmox-9-repair.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Proxmox 9 Boot Repair Session</title>
+  <style>
+    /* Default styles provided by pandoc.
+    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
+    */
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    /* CSS for syntax highlighting */
+    html { -webkit-text-size-adjust: 100%; }
+    pre > code.sourceCode { white-space: pre; position: relative; }
+    pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+    pre > code.sourceCode > span:empty { height: 1.2em; }
+    .sourceCode { overflow: visible; }
+    code.sourceCode > span { color: inherit; text-decoration: inherit; }
+    div.sourceCode { margin: 1em 0; }
+    pre.sourceCode { margin: 0; }
+    @media screen {
+    div.sourceCode { overflow: auto; }
+    }
+    @media print {
+    pre > code.sourceCode { white-space: pre-wrap; }
+    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+    }
+    pre.numberSource code
+      { counter-reset: source-line 0; }
+    pre.numberSource code > span
+      { position: relative; left: -4em; counter-increment: source-line; }
+    pre.numberSource code > span > a:first-child::before
+      { content: counter(source-line);
+        position: relative; left: -1em; text-align: right; vertical-align: baseline;
+        border: none; display: inline-block;
+        -webkit-touch-callout: none; -webkit-user-select: none;
+        -khtml-user-select: none; -moz-user-select: none;
+        -ms-user-select: none; user-select: none;
+        padding: 0 4px; width: 4em;
+        color: #aaaaaa;
+      }
+    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+    div.sourceCode
+      {   }
+    @media screen {
+    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+    }
+    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+    code span.at { color: #7d9029; } /* Attribute */
+    code span.bn { color: #40a070; } /* BaseN */
+    code span.bu { color: #008000; } /* BuiltIn */
+    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+    code span.ch { color: #4070a0; } /* Char */
+    code span.cn { color: #880000; } /* Constant */
+    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+    code span.dt { color: #902000; } /* DataType */
+    code span.dv { color: #40a070; } /* DecVal */
+    code span.er { color: #ff0000; font-weight: bold; } /* Error */
+    code span.ex { } /* Extension */
+    code span.fl { color: #40a070; } /* Float */
+    code span.fu { color: #06287e; } /* Function */
+    code span.im { color: #008000; font-weight: bold; } /* Import */
+    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+    code span.op { color: #666666; } /* Operator */
+    code span.ot { color: #007020; } /* Other */
+    code span.pp { color: #bc7a00; } /* Preprocessor */
+    code span.sc { color: #4070a0; } /* SpecialChar */
+    code span.ss { color: #bb6688; } /* SpecialString */
+    code span.st { color: #4070a0; } /* String */
+    code span.va { color: #19177c; } /* Variable */
+    code span.vs { color: #4070a0; } /* VerbatimString */
+    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+  </style>
+  <link rel="stylesheet" href="/assets/css/master.css" />
+  <script src="/assets/js/navigation.js" charset="utf-8"></script>
+</head>
+<body>
+<main class="main-content">
+<header id="title-block-header">
+<h1 class="title">Proxmox 9 Boot Repair Session</h1>
+</header>
+<nav id="TOC" role="doc-toc">
+<ul>
+<li><a href="#background" id="toc-background">Background</a>
+<ul>
+<li><a href="#what-happened" id="toc-what-happened">What
+Happened</a></li>
+<li><a href="#root-cause" id="toc-root-cause">Root Cause</a></li>
+<li><a href="#previous-repair-attempt-from-ubuntu"
+id="toc-previous-repair-attempt-from-ubuntu">Previous Repair Attempt
+(from Ubuntu)</a></li>
+</ul></li>
+<li><a href="#partition-layout" id="toc-partition-layout">Partition
+Layout</a></li>
+<li><a href="#repair-procedure-successful"
+id="toc-repair-procedure-successful">Repair Procedure (Successful)</a>
+<ul>
+<li><a href="#step-1-activate-lvm-mount-proxmox-root"
+id="toc-step-1-activate-lvm-mount-proxmox-root">Step 1: Activate LVM
+&amp; Mount Proxmox Root</a></li>
+<li><a href="#step-2-mount-efi-partition-inside-chroot-path"
+id="toc-step-2-mount-efi-partition-inside-chroot-path">Step 2: Mount EFI
+Partition Inside Chroot Path</a></li>
+<li><a href="#step-3-set-up-all-required-bind-mounts"
+id="toc-step-3-set-up-all-required-bind-mounts">Step 3: Set Up ALL
+Required Bind Mounts</a></li>
+<li><a href="#step-4-verify-chroot-environment"
+id="toc-step-4-verify-chroot-environment">Step 4: Verify Chroot
+Environment</a></li>
+<li><a href="#step-5-reinstall-grub-efi"
+id="toc-step-5-reinstall-grub-efi">Step 5: Reinstall GRUB EFI</a></li>
+<li><a href="#step-6-verify-installation"
+id="toc-step-6-verify-installation">Step 6: Verify Installation</a></li>
+<li><a href="#step-7-cleanup-unmount"
+id="toc-step-7-cleanup-unmount">Step 7: Cleanup &amp; Unmount</a></li>
+</ul></li>
+<li><a href="#key-takeaway" id="toc-key-takeaway">Key Takeaway</a></li>
+<li><a href="#post-repair" id="toc-post-repair">Post-Repair</a></li>
+</ul>
+</nav>
+<h2 id="background">Background</h2>
+<h3 id="what-happened">What Happened</h3>
+<ul>
+<li>Upgraded Proxmox VE 8 (Debian 12/Bookworm) → Proxmox VE 9 (Debian
+13/Trixie) on homelab server</li>
+<li>Main Proxmox drive: <code>nvme2n1</code> (Samsung 970 EVO Plus 1TB)
+using LVM</li>
+<li>Second drive with Ubuntu (“sulfur”): <code>sdc</code> (465.8GB) —
+used as rescue OS</li>
+<li><strong>Upgrade succeeded</strong> — all PVE 9 packages installed
+correctly</li>
+<li><strong>Boot failed</strong> — system dropped to BIOS after
+reboot</li>
+</ul>
+<h3 id="root-cause">Root Cause</h3>
+<p>Pre-upgrade warnings were not addressed: - <code>systemd-boot</code>
+package was installed (incompatible with Proxmox upgrades) -
+<code>grub-efi-amd64</code> was not installed (needed for UEFI boot) -
+EFI boot entry got corrupted/removed during upgrade</p>
+<h3 id="previous-repair-attempt-from-ubuntu">Previous Repair Attempt
+(from Ubuntu)</h3>
+<ol type="1">
+<li>Mounted Proxmox root (<code>/dev/mapper/pve-root</code>)</li>
+<li>Chrooted into Proxmox</li>
+<li>Installed <code>grub-efi-amd64</code></li>
+<li>Ran <code>grub-install /dev/nvme2n1</code> and
+<code>update-grub</code></li>
+<li><strong>Result</strong>: System changed from “dropping to BIOS” to
+showing “Welcome to GRUB” and stopping</li>
+<li><strong>Problem</strong>: Chroot was missing critical bind mounts
+(<code>/dev/pts</code>, <code>/run</code>,
+<code>/sys/firmware/efi/efivars</code>), so <code>grub-install</code>
+couldn’t write proper UEFI boot entries</li>
+</ol>
+<h2 id="partition-layout">Partition Layout</h2>
+<pre><code>Device Start End Sectors Size Type
+/dev/nvme2n1p1 34 2047 2014 1007K BIOS boot
+/dev/nvme2n1p2 2048 2099199 2097152 1G EFI System
+/dev/nvme2n1p3 2099200 1953525134 1951425935 930.5G Linux LVM</code></pre>
+<h2 id="repair-procedure-successful">Repair Procedure (Successful)</h2>
+<p>All commands run from Ubuntu on <code>sdc</code>.</p>
+<h3 id="step-1-activate-lvm-mount-proxmox-root">Step 1: Activate LVM
+&amp; Mount Proxmox Root</h3>
+<div class="sourceCode" id="cb2"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> vgscan</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> vgchange <span class="at">-ay</span></span></code></pre></div>
+<p>Output:</p>
+<pre><code>Found volume group &quot;pve&quot; using metadata type lvm2
+10 logical volume(s) in volume group &quot;pve&quot; now active</code></pre>
+<div class="sourceCode" id="cb4"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> mkdir <span class="at">-p</span> /mnt/proxmox</span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> mount /dev/mapper/pve-root /mnt/proxmox</span></code></pre></div>
+<p>Verified contents:
+<code>bin boot dev etc home lib lib64 lost+found media mnt opt proc root run sbin srv sys tmp tub usr var</code></p>
+<h3 id="step-2-mount-efi-partition-inside-chroot-path">Step 2: Mount EFI
+Partition Inside Chroot Path</h3>
+<p><strong>Critical</strong>: Must be at
+<code>/mnt/proxmox/boot/efi</code>, NOT a separate mountpoint.</p>
+<div class="sourceCode" id="cb5"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> mkdir <span class="at">-p</span> /mnt/proxmox/boot/efi</span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> mount /dev/nvme2n1p2 /mnt/proxmox/boot/efi</span></code></pre></div>
+<p>Existing EFI contents: <code>EFI/BOOT</code>, <code>EFI/Dell</code>,
+<code>EFI/proxmox</code> (from previous attempt)</p>
+<h3 id="step-3-set-up-all-required-bind-mounts">Step 3: Set Up ALL
+Required Bind Mounts</h3>
+<p>This was the key fix — the previous attempt only had
+<code>/dev</code>, <code>/proc</code>, <code>/sys</code>.</p>
+<div class="sourceCode" id="cb6"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> mount <span class="at">--bind</span> /dev /mnt/proxmox/dev</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> mount <span class="at">--bind</span> /dev/pts /mnt/proxmox/dev/pts</span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> mount <span class="at">--bind</span> /proc /mnt/proxmox/proc</span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> mount <span class="at">--bind</span> /sys /mnt/proxmox/sys</span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> mount <span class="at">--bind</span> /run /mnt/proxmox/run</span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> mount <span class="at">--bind</span> /sys/firmware/efi/efivars /mnt/proxmox/sys/firmware/efi/efivars</span></code></pre></div>
+<p>The <code>efivars</code> bind mount is <strong>critical</strong> —
+without it, <code>grub-install</code> cannot write UEFI boot
+variables.</p>
+<h3 id="step-4-verify-chroot-environment">Step 4: Verify Chroot
+Environment</h3>
+<div class="sourceCode" id="cb7"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> chroot /mnt/proxmox /bin/bash <span class="at">-c</span> <span class="st">&#39;</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="st">cat /etc/debian_version</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a><span class="st">ls /boot/efi/EFI/</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a><span class="st">ls /boot/vmlinuz-*</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a><span class="st">ls /sys/firmware/efi/efivars/ | head -3</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a><span class="st">dpkg -l proxmox-ve | tail -1</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a><span class="st">dpkg -l grub-efi-amd64 | tail -1</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a><span class="st">&#39;</span></span></code></pre></div>
+<p>Results: - Debian version: <strong>13.4</strong> (Trixie) - Proxmox
+VE: <strong>9.1.0</strong> - grub-efi-amd64:
+<strong>2.12-9+pmx2</strong> - Kernels available:
+<code>6.17.13-2-pve</code> (newest), <code>6.8.12-20-pve</code>, and 10
+others - efivars: <strong>accessible</strong> ✓</p>
+<h3 id="step-5-reinstall-grub-efi">Step 5: Reinstall GRUB EFI</h3>
+<div class="sourceCode" id="cb8"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> chroot /mnt/proxmox /bin/bash <span class="at">-c</span> <span class="st">&#39;</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="st">apt install --reinstall grub-efi-amd64 -y</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="st">&#39;</span></span></code></pre></div>
+<p>Output:</p>
+<pre><code>Installing for x86_64-efi platform.
+Installation finished. No error reported.
+Generating grub configuration file ...
+Found linux image: /boot/vmlinuz-6.17.13-2-pve
+Found initrd image: /boot/initrd.img-6.17.13-2-pve
+[... 12 kernels total ...]
+Found memtest86+ 64bit EFI image: /boot/memtest86+x64.efi
+Adding boot menu entry for UEFI Firmware Settings ...
+done</code></pre>
+<p>Then explicitly ran <code>grub-install</code> with proper flags:</p>
+<div class="sourceCode" id="cb10"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> chroot /mnt/proxmox /bin/bash <span class="at">-c</span> <span class="st">&#39;</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a><span class="st">grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=proxmox --recheck</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a><span class="st">update-grub</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a><span class="st">&#39;</span></span></code></pre></div>
+<p>Both commands: <strong>Exit code 0</strong>, no errors.</p>
+<h3 id="step-6-verify-installation">Step 6: Verify Installation</h3>
+<div class="sourceCode" id="cb11"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> chroot /mnt/proxmox /bin/bash <span class="at">-c</span> <span class="st">&#39;</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="st">ls -la /boot/efi/EFI/proxmox/</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="st">grep -m3 &quot;menuentry&quot; /boot/grub/grub.cfg</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="st">efibootmgr -v</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a><span class="st">blkid /dev/mapper/pve-root</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a><span class="st">&#39;</span></span></code></pre></div>
+<p>Results: - <code>grubx64.efi</code> — freshly rebuilt (Mar 20 09:10)
+- <strong>UEFI Boot Entries</strong>:
+<code>BootCurrent: 0002  Timeout: 1 seconds  BootOrder: 0000,0001,0002  Boot0000* proxmox HD(2,GPT,...)/File(\EFI\proxmox\grubx64.efi)  Boot0001* UEFI OS HD(2,GPT,...)/File(\EFI\BOOT\BOOTX64.EFI)  Boot0002* ubuntu HD(1,GPT,...)/File(\EFI\ubuntu\shimx64.efi)</code>
+- “proxmox” is <strong>first</strong> in boot order ✓ -
+<code>grub.cfg</code> uses <code>lvmid</code> to reference root volume ✓
+- Root FS: <code>/dev/mapper/pve-root</code>
+UUID=<code>7b271119-e217-44ce-a1eb-3e98bc88e7fa</code> ext4 ✓</p>
+<h3 id="step-7-cleanup-unmount">Step 7: Cleanup &amp; Unmount</h3>
+<div class="sourceCode" id="cb12"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> umount /mnt/proxmox/sys/firmware/efi/efivars</span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> umount /mnt/proxmox/run</span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> umount /mnt/proxmox/sys</span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> umount /mnt/proxmox/proc</span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> umount /mnt/proxmox/dev/pts</span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> umount /mnt/proxmox/dev</span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> umount /mnt/proxmox/boot/efi</span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a><span class="fu">sudo</span> umount /mnt/proxmox</span></code></pre></div>
+<p>All unmounted successfully.</p>
+<h2 id="key-takeaway">Key Takeaway</h2>
+<p>The fix was ensuring the chroot had <strong>all 6 bind
+mounts</strong>, especially: - <code>/dev/pts</code> — pseudo-terminal
+devices - <code>/run</code> — runtime data needed by GRUB scripts -
+<code>/sys/firmware/efi/efivars</code> — <strong>the critical
+one</strong> — allows <code>grub-install</code> to write UEFI NVRAM boot
+entries via the kernel’s EFI variable interface</p>
+<p>Without <code>efivars</code>, <code>grub-install</code> installs the
+binary to the EFI partition but <strong>cannot register a boot
+entry</strong> in the UEFI firmware, and the EFI binary may have an
+incorrect embedded prefix path, causing the “Welcome to GRUB” hang.</p>
+<h2 id="post-repair">Post-Repair</h2>
+<p>After reboot, the system should: 1. UEFI firmware loads
+<code>\EFI\proxmox\grubx64.efi</code> from nvme2n1p2 2. GRUB displays
+menu with Proxmox VE 6.17.13-2-pve as default 3. Boots into Proxmox VE
+9.1.0 (Debian 13 Trixie) 4. All VMs and data on LVM volumes should be
+intact</p>
+</main>
+<script src="/assets/js/footer.js" charset="utf-8"></script>
+<hr>
+<script src="https://utteranc.es/client.js"
+        repo="erietz/erietz.github.io"
+        issue-term="pathname"
+        theme="github-light"
+        crossorigin="anonymous"
+        async>
+</script>
+<hr>
+</body>
+</html>

--- a/posts/index.html
+++ b/posts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
@@ -9,7 +9,6 @@
     /* Default styles provided by pandoc.
     ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
     */
-    code{white-space: pre-wrap;}
     span.smallcaps{font-variant: small-caps;}
     div.columns{display: flex; gap: min(4vw, 1.5em);}
     div.column{flex: auto; overflow-x: auto;}
@@ -41,6 +40,15 @@
 <col style="width: 23%" />
 </colgroup>
 <tbody>
+<tr>
+<td style="text-align: left;">Ɣ</td>
+<td style="text-align: left;">2026-03-20</td>
+<td style="text-align: left;"><a
+href="2026-03-20-proxmox-9-repair.html">Proxmox 9 Boot Repair
+Session</a></td>
+<td style="text-align: left;"><em>linux, proxmox, homelab,
+debian</em></td>
+</tr>
 <tr>
 <td style="text-align: left;">Ɣ</td>
 <td style="text-align: left;">2023-01-16</td>

--- a/src/posts/2026-03-20-proxmox-9-repair.md
+++ b/src/posts/2026-03-20-proxmox-9-repair.md
@@ -1,0 +1,200 @@
+---
+title: Proxmox 9 Boot Repair Session
+categories:
+  - linux
+  - proxmox
+  - homelab
+  - debian
+---
+
+## Background
+
+### What Happened
+- Upgraded Proxmox VE 8 (Debian 12/Bookworm) → Proxmox VE 9 (Debian 13/Trixie) on homelab server
+- Main Proxmox drive: `nvme2n1` (Samsung 970 EVO Plus 1TB) using LVM
+- Second drive with Ubuntu ("sulfur"): `sdc` (465.8GB) — used as rescue OS
+- **Upgrade succeeded** — all PVE 9 packages installed correctly
+- **Boot failed** — system dropped to BIOS after reboot
+
+### Root Cause
+Pre-upgrade warnings were not addressed:
+- `systemd-boot` package was installed (incompatible with Proxmox upgrades)
+- `grub-efi-amd64` was not installed (needed for UEFI boot)
+- EFI boot entry got corrupted/removed during upgrade
+
+### Previous Repair Attempt (from Ubuntu)
+1. Mounted Proxmox root (`/dev/mapper/pve-root`)
+2. Chrooted into Proxmox
+3. Installed `grub-efi-amd64`
+4. Ran `grub-install /dev/nvme2n1` and `update-grub`
+5. **Result**: System changed from "dropping to BIOS" to showing "Welcome to GRUB" and stopping
+6. **Problem**: Chroot was missing critical bind mounts (`/dev/pts`, `/run`, `/sys/firmware/efi/efivars`), so `grub-install` couldn't write proper UEFI boot entries
+
+## Partition Layout
+
+```
+Device Start End Sectors Size Type
+/dev/nvme2n1p1 34 2047 2014 1007K BIOS boot
+/dev/nvme2n1p2 2048 2099199 2097152 1G EFI System
+/dev/nvme2n1p3 2099200 1953525134 1951425935 930.5G Linux LVM
+```
+
+## Repair Procedure (Successful)
+
+All commands run from Ubuntu on `sdc`.
+
+### Step 1: Activate LVM & Mount Proxmox Root
+
+```bash
+sudo vgscan
+sudo vgchange -ay
+```
+
+Output:
+```
+Found volume group "pve" using metadata type lvm2
+10 logical volume(s) in volume group "pve" now active
+```
+
+```bash
+sudo mkdir -p /mnt/proxmox
+sudo mount /dev/mapper/pve-root /mnt/proxmox
+```
+
+Verified contents: `bin boot dev etc home lib lib64 lost+found media mnt opt proc root run sbin srv sys tmp tub usr var`
+
+### Step 2: Mount EFI Partition Inside Chroot Path
+
+**Critical**: Must be at `/mnt/proxmox/boot/efi`, NOT a separate mountpoint.
+
+```bash
+sudo mkdir -p /mnt/proxmox/boot/efi
+sudo mount /dev/nvme2n1p2 /mnt/proxmox/boot/efi
+```
+
+Existing EFI contents: `EFI/BOOT`, `EFI/Dell`, `EFI/proxmox` (from previous attempt)
+
+### Step 3: Set Up ALL Required Bind Mounts
+
+This was the key fix — the previous attempt only had `/dev`, `/proc`, `/sys`.
+
+```bash
+sudo mount --bind /dev /mnt/proxmox/dev
+sudo mount --bind /dev/pts /mnt/proxmox/dev/pts
+sudo mount --bind /proc /mnt/proxmox/proc
+sudo mount --bind /sys /mnt/proxmox/sys
+sudo mount --bind /run /mnt/proxmox/run
+sudo mount --bind /sys/firmware/efi/efivars /mnt/proxmox/sys/firmware/efi/efivars
+```
+
+The `efivars` bind mount is **critical** — without it, `grub-install` cannot write UEFI boot variables.
+
+### Step 4: Verify Chroot Environment
+
+```bash
+sudo chroot /mnt/proxmox /bin/bash -c '
+cat /etc/debian_version
+ls /boot/efi/EFI/
+ls /boot/vmlinuz-*
+ls /sys/firmware/efi/efivars/ | head -3
+dpkg -l proxmox-ve | tail -1
+dpkg -l grub-efi-amd64 | tail -1
+'
+```
+
+Results:
+- Debian version: **13.4** (Trixie)
+- Proxmox VE: **9.1.0**
+- grub-efi-amd64: **2.12-9+pmx2**
+- Kernels available: `6.17.13-2-pve` (newest), `6.8.12-20-pve`, and 10 others
+- efivars: **accessible** ✓
+
+### Step 5: Reinstall GRUB EFI
+
+```bash
+sudo chroot /mnt/proxmox /bin/bash -c '
+apt install --reinstall grub-efi-amd64 -y
+'
+```
+
+Output:
+```
+Installing for x86_64-efi platform.
+Installation finished. No error reported.
+Generating grub configuration file ...
+Found linux image: /boot/vmlinuz-6.17.13-2-pve
+Found initrd image: /boot/initrd.img-6.17.13-2-pve
+[... 12 kernels total ...]
+Found memtest86+ 64bit EFI image: /boot/memtest86+x64.efi
+Adding boot menu entry for UEFI Firmware Settings ...
+done
+```
+
+Then explicitly ran `grub-install` with proper flags:
+
+```bash
+sudo chroot /mnt/proxmox /bin/bash -c '
+grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=proxmox --recheck
+update-grub
+'
+```
+
+Both commands: **Exit code 0**, no errors.
+
+### Step 6: Verify Installation
+
+```bash
+sudo chroot /mnt/proxmox /bin/bash -c '
+ls -la /boot/efi/EFI/proxmox/
+grep -m3 "menuentry" /boot/grub/grub.cfg
+efibootmgr -v
+blkid /dev/mapper/pve-root
+'
+```
+
+Results:
+- `grubx64.efi` — freshly rebuilt (Mar 20 09:10)
+- **UEFI Boot Entries**:
+ ```
+ BootCurrent: 0002
+ Timeout: 1 seconds
+ BootOrder: 0000,0001,0002
+ Boot0000* proxmox HD(2,GPT,...)/File(\EFI\proxmox\grubx64.efi)
+ Boot0001* UEFI OS HD(2,GPT,...)/File(\EFI\BOOT\BOOTX64.EFI)
+ Boot0002* ubuntu HD(1,GPT,...)/File(\EFI\ubuntu\shimx64.efi)
+ ```
+- "proxmox" is **first** in boot order ✓
+- `grub.cfg` uses `lvmid` to reference root volume ✓
+- Root FS: `/dev/mapper/pve-root` UUID=`7b271119-e217-44ce-a1eb-3e98bc88e7fa` ext4 ✓
+
+### Step 7: Cleanup & Unmount
+
+```bash
+sudo umount /mnt/proxmox/sys/firmware/efi/efivars
+sudo umount /mnt/proxmox/run
+sudo umount /mnt/proxmox/sys
+sudo umount /mnt/proxmox/proc
+sudo umount /mnt/proxmox/dev/pts
+sudo umount /mnt/proxmox/dev
+sudo umount /mnt/proxmox/boot/efi
+sudo umount /mnt/proxmox
+```
+
+All unmounted successfully.
+
+## Key Takeaway
+
+The fix was ensuring the chroot had **all 6 bind mounts**, especially:
+- `/dev/pts` — pseudo-terminal devices
+- `/run` — runtime data needed by GRUB scripts
+- `/sys/firmware/efi/efivars` — **the critical one** — allows `grub-install` to write UEFI NVRAM boot entries via the kernel's EFI variable interface
+
+Without `efivars`, `grub-install` installs the binary to the EFI partition but **cannot register a boot entry** in the UEFI firmware, and the EFI binary may have an incorrect embedded prefix path, causing the "Welcome to GRUB" hang.
+
+## Post-Repair
+
+After reboot, the system should:
+1. UEFI firmware loads `\EFI\proxmox\grubx64.efi` from nvme2n1p2
+2. GRUB displays menu with Proxmox VE 6.17.13-2-pve as default
+3. Boots into Proxmox VE 9.1.0 (Debian 13 Trixie)
+4. All VMs and data on LVM volumes should be intact

--- a/src/posts/2026-03-20-proxmox-9-repair.md
+++ b/src/posts/2026-03-20-proxmox-9-repair.md
@@ -7,6 +7,10 @@ categories:
   - debian
 ---
 
+## Intro
+
+I managed to botch my Proxmox installation in a rather classic way: I tried to upgrade from Debian 12 to 13 while watching *The Pitt* on HBO Max, only half paying attention. Predictably, I missed some critical pre-upgrade warnings, and my system wouldn't boot. This post documents the successful repair procedure for anyone else who might find themselves in a similar situation (distracted or otherwise).
+
 ## Background
 
 ### What Happened

--- a/src/posts/index.md
+++ b/src/posts/index.md
@@ -5,6 +5,7 @@ title: Posts
 <center>
 |     |       |      |      |
 |:--- | :---- | :--- | :--- |
+| Ɣ | 2026-03-20 | [Proxmox 9 Boot Repair Session](2026-03-20-proxmox-9-repair.md) | *linux, proxmox, homelab, debian* |
 | Ɣ | 2023-01-16 | [Download Canvas Course Materials](2023-01-16-download-canvas-materials.md) | *web, lifehack* |
 | Ɣ | 2022-12-13 | [Home Server Upgrade (Part 3)](2022-12-13-incremental-backups.md) | *linux, backups* |
 | Ɣ | 2022-05-12 | [Home Server Upgrade (Part 2)](2022-05-12-home-server-part2.md) | *linux, wifi* |


### PR DESCRIPTION
Adds a new blog post documenting the successful repair of a Proxmox 9 boot failure after a Debian Trixie upgrade. Includes details on partition layout, chroot repair procedure, and critical bind mounts.